### PR TITLE
revert: "chore: Bump markdown-it-cjk-breaks from 1.1.3 to 2.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "disqusjs": "1.3.0",
     "markdown-it-abbr": "2.0.0",
     "markdown-it-attrs": "4.2.0",
-    "markdown-it-cjk-breaks": "2.0.0",
+    "markdown-it-cjk-breaks": "1.1.3",
     "markdown-it-figure-gallery": "0.2.0",
     "markdown-it-footnote": "4.0.0",
     "prismjs": "^1.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,6 +1725,11 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+eastasianwidth@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -2246,11 +2251,6 @@ functions-have-names@^1.2.2, functions-have-names@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
-
-get-east-asian-width@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz#5e6ebd9baee6fb8b7b6bd505221065f0cd91f64e"
-  integrity sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==
 
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.0, get-intrinsic@^1.2.1:
   version "1.2.1"
@@ -3148,12 +3148,12 @@ markdown-it-attrs@4.2.0:
   resolved "https://registry.yarnpkg.com/markdown-it-attrs/-/markdown-it-attrs-4.2.0.tgz#a1affc41d7606697654d6025f733a80e96042aa0"
   integrity sha512-m7svtUBythvcGFFZAv9VjMEvs8UbHri2sojJ3juJumoOzv8sdkx9a7W3KxiHbXxAbvL3Xauak8TMwCnvigVPKw==
 
-markdown-it-cjk-breaks@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/markdown-it-cjk-breaks/-/markdown-it-cjk-breaks-2.0.0.tgz#c4bda243cfd6bd8d9b0666a3f54808ac4ff86791"
-  integrity sha512-hzgyuNzXuHoNJuPW+b4IXEtqaLeD4xNloqFVWG/wzT3O0npoDiwaEFY6JiglFjUh5//xvE0N21GU07NMxw4TiA==
+markdown-it-cjk-breaks@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/markdown-it-cjk-breaks/-/markdown-it-cjk-breaks-1.1.3.tgz#11cf76ab271f68b5ae0c6747747f404631b73545"
+  integrity sha512-/gX3LueMp+5FdUkqcFPK5nHI6t85uq1rMv8yhrmCOZhU90XqybQj8OT1hVrxrdseajaHLPBK43xLzEKPosgTDA==
   dependencies:
-    get-east-asian-width "^1.2.0"
+    eastasianwidth "~0.2.0"
 
 markdown-it-footnote@4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Reverts chawyehsu/chawyehsu.com#315

upstream fix: https://github.com/markdown-it/markdown-it-cjk-breaks/pull/5